### PR TITLE
chore: add chalk as package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.21.4",
         "axios": "^1.3.5",
+        "chalk": "^2.0.0",
         "commander": "^10.0.0",
         "tar": "^6.1.13",
         "toml": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/core": "^7.21.4",
     "axios": "^1.3.5",
+    "chalk": "^2.0.0",
     "commander": "^10.0.0",
     "tar": "^6.1.13",
     "toml": "^3.0.0"


### PR DESCRIPTION
Cause I have other dependencies using `chalk` `^5.0.0` and `wasm-pkg-build` is currently not compatible with.

So I added `chalk` `^2.0.0` to the `package.json` to avoid this peed dependency problem.

You may need to update `wasm-pkg-build` to be compatible with `chalk` `^5.0.0` further.