### PR TITLE
feat: support HTTPS_PROXY environment variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.6.8",
         "chalk": "^2",
         "commander": "^12.0.0",
+        "https-proxy-agent": "^7.0.4",
         "tar": "^7.0.0",
         "toml": "^3.0.0"
       },
@@ -538,6 +539,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -891,6 +903,18 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.6.8",
     "chalk": "^2",
     "commander": "^12.0.0",
+    "https-proxy-agent": "^7.0.4",
     "tar": "^7.0.0",
     "toml": "^3.0.0"
   },

--- a/src/install/helper.ts
+++ b/src/install/helper.ts
@@ -12,6 +12,7 @@ export interface InstallOptions {
 
 export async function getLatestVersion(author: string, name: string, command?: string) {
   let url = `https://api.github.com/repos/${author}/${name}/releases/latest`;
+  debug(`Fetching ${url} to get latest version of ${command ?? name}`);
   let opts: AxiosRequestConfig = {};
   if (process.env["GITHUB_TOKEN"]) {
     opts.headers = { "Authorization": `token ${process.env["GITHUB_TOKEN"]}` };
@@ -20,7 +21,7 @@ export async function getLatestVersion(author: string, name: string, command?: s
     const res = await axios.get(`https://api.github.com/repos/${author}/${name}/releases/latest`, opts)
     return res.data.tag_name
   } catch (err) {
-    throw new Error(`Failed to get latest version of '${command ?? name}', fetch '${url}': ${err?.message || err}`);
+    throw new Error(`Failed to get latest version of ${command ?? name}, ${err?.message || err}`);
   }
 }
 
@@ -56,6 +57,6 @@ export async function getOrInstall(url: string, exePath: string, options: Instal
       return binaryPath
     })
     .catch(e => {
-      throw new Error(`Failed to install ${name}, ${e.message}`);
+      throw new Error(`Failed to install ${name} to ${binaryPath}, ${e.message}`);
     });
 }

--- a/src/install/helper.ts
+++ b/src/install/helper.ts
@@ -11,15 +11,16 @@ export interface InstallOptions {
 }
 
 export async function getLatestVersion(author: string, name: string, command?: string) {
+  let url = `https://api.github.com/repos/${author}/${name}/releases/latest`;
+  let opts: AxiosRequestConfig = {};
+  if (process.env["GITHUB_TOKEN"]) {
+    opts.headers = { "Authorization": `token ${process.env["GITHUB_TOKEN"]}` };
+  }
   try {
-    let opts: AxiosRequestConfig = {};
-    if (process.env["GITHUB_TOKEN"]) {
-      opts.headers = { "Authorization": `token ${process.env["GITHUB_TOKEN"]}` };
-    }
     const res = await axios.get(`https://api.github.com/repos/${author}/${name}/releases/latest`, opts)
     return res.data.tag_name
   } catch (err) {
-    throw new Error(`Failed to get latest version of '${command ?? name}', ${err?.message || err}`);
+    throw new Error(`Failed to get latest version of '${command ?? name}', fetch '${url}': ${err?.message || err}`);
   }
 }
 
@@ -27,7 +28,7 @@ export async function getLatestVersion(author: string, name: string, command?: s
 export async function getOrInstall(url: string, exePath: string, options: InstallOptions) {
   const name = path.basename(exePath, '.exe');
   const binaryPath = join(options.cacheDir, exePath);
-  
+
   if (await exists(binaryPath)) {
     return binaryPath
   }


### PR DESCRIPTION
PR supports proxy networks through the HTTPS_PROXY environment variable, enabling it to download required tools like wasm-bindgen and wasm-opt within networks that require a proxy for external connections.