### PR TITLE
feat: remove https-proxy and add user-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "axios": "^1.6.8",
         "chalk": "^2",
         "commander": "^12.0.0",
-        "https-proxy-agent": "^7.0.4",
         "tar": "^7.0.0",
         "toml": "^3.0.0"
       },
@@ -539,17 +538,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -903,18 +891,6 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "axios": "^1.6.8",
     "chalk": "^2",
     "commander": "^12.0.0",
-    "https-proxy-agent": "^7.0.4",
     "tar": "^7.0.0",
     "toml": "^3.0.0"
   },

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -39,7 +39,8 @@ program
       wasmOptVersion: opts.wasmOptVersion,
       install: {
         cacheDir: getCacheDir('wasm-pkg-build'),
-        downloadTimeout: 60000,
+        downloadBinaryTimeout: 60000,
+        getVersionTimeout: 60000,
         userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
         verbose: !!opts.verbose,
       }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,6 @@
 
 import { Command, InvalidOptionArgumentError } from 'commander';
 import path from 'path';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { BuildOptions, build, SUPPORT_MODULES } from './index';
 import { getCacheDir } from './utils';
 
@@ -27,10 +26,6 @@ program
     const opts = program.opts();
     const dir = path.resolve(crate ?? process.cwd());
     const outDir = path.resolve(opts.outDir ?? path.resolve(dir, "pkg"));
-    let httpsAgent = null;
-    if (process.env["HTTPS_PROXY"]) {
-      httpsAgent = new HttpsProxyAgent(process.env["HTTPS_PROXY"]);
-    }
     const options: BuildOptions = {
       dir,
       outDir,
@@ -44,7 +39,8 @@ program
       wasmOptVersion: opts.wasmOptVersion,
       install: {
         cacheDir: getCacheDir('wasm-pkg-build'),
-        axiosConfig: { httpsAgent, timeout: 60000 },
+        downloadTimeout: 60000,
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
         verbose: !!opts.verbose,
       }
     };

--- a/src/install/wasm-opt.ts
+++ b/src/install/wasm-opt.ts
@@ -2,11 +2,12 @@ import { getLatestVersion, getOrInstall, InstallOptions } from "./helper";
 
 export async function getWasmOpt(options: InstallOptions, version?: string) {
   if (!version || version == "latest") {
-    version = await getLatestVersion('WebAssembly', 'binaryen', 'wasm-opt');
-  }  else if (/^\d+$/.test(version)) {
+    const repo = { owner: "WebAssembly", name: "binaryen", command: "wasm-opt" };
+    version = await getLatestVersion(repo, options);
+  } else if (/^\d+$/.test(version)) {
     version = "version_" + version;
   }
-  const [url, exePath] =  await getUrlAndExePath('WebAssembly', 'binaryen', version);
+  const [url, exePath] = await getUrlAndExePath('WebAssembly', 'binaryen', version);
   return getOrInstall(url, exePath, options);
 }
 


### PR DESCRIPTION
GitHub's risk control mechanism may be prone to returning a 503 error when the user agent is absent in the API request.
The https-proxy seems useless.